### PR TITLE
Build and run snack-shop-be with docker

### DIFF
--- a/snack-shop-be/Dockerfile
+++ b/snack-shop-be/Dockerfile
@@ -1,0 +1,17 @@
+# Dockerfile for Snack Shop Backend
+FROM gradle:8.8.0-jdk21-alpine as builder
+
+WORKDIR /builder
+COPY ./build.gradle.kts /builder/
+COPY ./settings.gradle.kts /builder/
+COPY ./src/ /builder/src/
+RUN gradle build --stacktrace
+
+COPY src /app/src
+RUN set -x && gradle build
+
+FROM amazoncorretto:21-alpine3.19
+WORKDIR /app
+EXPOSE 8080
+COPY --from=builder /builder/build/libs/snackshop.jar .
+ENTRYPOINT ["java", "-Dspring.data.mongodb.uri=mongodb://mongodb/snack-shop", "-jar", "snackshop.jar"]

--- a/snack-shop-be/build.gradle.kts
+++ b/snack-shop-be/build.gradle.kts
@@ -8,7 +8,8 @@ plugins {
 }
 
 group = "com.makebelievelabs"
-version = "0.0.1-SNAPSHOT"
+// version = "0.0.1-SNAPSHOT"
+// TODO: Use semantic versioning and get it working with DOCKER
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_21

--- a/snack-shop-be/docker-compose.yml
+++ b/snack-shop-be/docker-compose.yml
@@ -7,3 +7,10 @@ services:
       - '27017:27017'
     volumes:
       - ./db:/data/db
+  snack-shop-be:
+    build: .
+    restart: always
+    ports: 
+      - '8080:8080'
+    depends_on:
+      - mongodb


### PR DESCRIPTION
NOTE: I've disabled the snapshot versioning, to make it easier to run in docker. We can add that back in later.